### PR TITLE
Some new ideas :)

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+erl +SDio 1 +SDPcpu 50 -noinput -s aggregate2 run "$1" -eval "erlang:halt()."

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,4 @@ if [ "$2" != "" ]; then
     MODULE="$2"
 fi
 
-# +SDio 1 +SDPcpu 50
-
-erl +sbwt none +sbwtdio none +JPperf true -noinput -s "$MODULE" run "$1" -eval "erlang:halt()."
+erl +SDio 1 +SDPcpu 50 +sbwt none +sbwtdio none -noinput -s "$MODULE" run "$1" -eval "erlang:halt()."

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 
-erl +SDio 1 +SDPcpu 50 -noinput -s aggregate2 run "$1" -eval "erlang:halt()."
+MODULE=aggregate2
+if [ "$2" != "" ]; then
+    MODULE="$2"
+fi
+
+# +SDio 1 +SDPcpu 50
+
+erl +sbwt none +sbwtdio none +JPperf true -noinput -s "$MODULE" run "$1" -eval "erlang:halt()."

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+erlc src/aggregate2.erl

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+erlc src/aggregate.erl
 erlc src/aggregate2.erl

--- a/src/aggregate.erl
+++ b/src/aggregate.erl
@@ -1,12 +1,17 @@
 -module(aggregate).
 
--export([ aggregate_measurements/2
+-export([ run/1
+        , aggregate_measurements/2
         , chunk_processor/0
         , line_processor/0
         , parse_float/1
         ]).
 
 -include_lib("eunit/include/eunit.hrl").
+
+run([Filename]) ->
+%    logger:update_primary_config(#{ level => none }),
+    aggregate_measurements(atom_to_list(Filename), [{bufsize, 2 * 1024 * 1024}]).
 
 aggregate_measurements(Filename, Opts) ->
   process_flag(trap_exit, true),

--- a/src/aggregate2.erl
+++ b/src/aggregate2.erl
@@ -1,0 +1,239 @@
+-module(aggregate2).
+
+-export([ aggregate_measurements/2
+        , chunk_processor/0
+        , line_processor/0
+        , parse_float/1
+        ]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+aggregate_measurements(Filename, Opts) ->
+  process_flag(trap_exit, true),
+  Start = erlang:monotonic_time(),
+  BufSize = proplists:get_value(bufsize, Opts),
+  logger:info(#{bufsize => BufSize}),
+  {ok, FD} = prim_file:open(Filename, [read]),
+  NumProcessors =
+    proplists:get_value(parallel, Opts, erlang:system_info(schedulers) div 2),
+  {ProcessorPids, AllPids} = start_processors(NumProcessors),
+  read_chunks(FD, 0, 0, <<>>, BufSize, ProcessorPids),
+  Now = erlang:monotonic_time(),
+  logger:info(#{label => "All chunks read, waiting for processors to finish",
+                elapsed_secs => (Now - Start) / 1000_000_000.0}),
+  Map = wait_for_completion(AllPids, #{}),
+
+  %% ?assertMatch({_, 180, _, _}, maps:get(<<"Abha">>, Map)),
+  Fmt = format_final_map(Map),
+  case proplists:get_value(no_output, Opts, false) of
+    true -> ok;
+    false ->
+      io:format("~ts~n", [Fmt])
+  end.
+
+start_processors(NumProcs) ->
+  logger:info(#{label => "Starting processing pipelines",
+                num_pipelines => NumProcs}),
+  lists:foldl(
+    fun(_, {ProcessorPids, AllPids}) ->
+        LineProcessorPid = proc_lib:start_link(?MODULE, line_processor, []),
+        ProcessorPid = proc_lib:start_link(?MODULE, chunk_processor, []),
+        ProcessorPid ! {line_processor, LineProcessorPid},
+        LineProcessorPid ! {result_pid, self()},
+        {[ProcessorPid|ProcessorPids],
+         [ProcessorPid, LineProcessorPid|AllPids]}
+    end, {[], []}, lists:seq(1, NumProcs)).
+
+read_chunks(FD, N, Offset, PrevChunk, BufSize, TargetPids) ->
+  TargetPid = lists:nth((N rem length(TargetPids)) + 1, TargetPids),
+  case prim_file:pread(FD, Offset, BufSize) of
+    {ok, Bin} ->
+      Size = byte_size(Bin),
+      %% Read chunks pair-wise and split them so that each processed
+      %% chunk is on an even newline boundary
+      case binary:split(Bin, <<"\n">>) of
+        [First, NextChunk] ->
+          send_chunk([PrevChunk, First], TargetPid),
+          %% sleep_if_target_pid_mql_too_long(TargetPid, 20),
+          read_chunks(FD, N + 1, Offset + Size, NextChunk, BufSize, TargetPids);
+        [Chunk] ->
+          send_chunk([Chunk], TargetPid),
+          read_chunks(FD, N + 1, Offset + Size, <<>>, BufSize, TargetPids)
+      end;
+    eof ->
+      %% Reached end of file, process the last chunk
+      send_chunk([PrevChunk], TargetPid),
+      lists:foreach(fun(Pid) -> Pid ! eof end, TargetPids),
+      ok
+  end.
+
+send_chunk(Chunk, TargetPid) ->
+  TargetPid ! {chunk, Chunk}.
+
+wait_for_completion([], Map) ->
+  logger:info(#{label => "All subprocesses finished"}),
+  Map;
+wait_for_completion(Pids, Map) ->
+  receive
+    {'EXIT', Pid, normal} ->
+      wait_for_completion(Pids -- [Pid], Map);
+    {result, SenderPid, NewMap} ->
+      logger:info(#{label => "Got result",
+                    sender => SenderPid,
+                    result_size => maps:size(NewMap)}),
+      wait_for_completion(Pids, merge_location_data(Map, NewMap));
+    _ ->
+      logger:error(#{label => "Unexpected message"})
+  end.
+
+merge_location_data(Map1, Map2) ->
+  Stations = lists:usort(maps:keys(Map1) ++ maps:keys(Map2)),
+  lists:foldl(
+    fun(Station, Map) when Station =:= '$ancestors' orelse
+                           Station =:= '$initial_call' ->
+        Map;
+       (Station, Map) ->
+        case {maps:get(Station, Map1, undefined),
+              maps:get(Station, Map2, undefined)} of
+          {Data1, undefined} -> maps:put(Station, Data1, Map);
+          {undefined, Data2} -> maps:put(Station, Data2, Map);
+          {Data1, Data2} ->
+            {Min1, Max1, Count1, Sum1} = Data1,
+            {Min2, Max2, Count2, Sum2} = Data2,
+            maps:put(
+              Station,
+              {min(Min1, Min2),
+               max(Max1, Max2),
+               Count1 + Count2,
+               Sum1 + Sum2},
+              Map)
+        end
+    end, #{}, Stations).
+
+format_final_map(Map) ->
+  "{" ++
+    lists:join(
+      ", ",
+      lists:map(
+        fun({Station, {Min, Max, Count, Sum}}) ->
+            Mean = Sum / Count,
+            io_lib:format("~ts=~.1f/~.1f/~.1f",
+                          [Station, Min/10, Mean/10, Max/10])
+        end, lists:sort(maps:to_list(Map))))
+    ++ "}".
+
+%%
+%% Chunk processor: this step in the pipeline takes a binary
+%% consisting of an even number of line, splits it at "\n" and ";" and
+%% passes it on to the line processor.
+%%
+chunk_processor() ->
+  proc_lib:init_ack(self()),
+  logger:info(#{label => "Chunk processor running"}),
+  chunk_processor_loop(undefined).
+
+chunk_processor_loop(Pid) ->
+  receive
+    {line_processor, LineProcessorPid} ->
+      chunk_processor_loop(LineProcessorPid);
+    {chunk, [Chunk]} ->
+      Pid ! {lines, {binary:split(Chunk, [<<"\n">>, <<";">>], [global]), <<>>}},
+      chunk_processor_loop(Pid);
+    {chunk, [First, Second]} ->
+          Pid ! {lines, {binary:split(First, [<<"\n">>, <<";">>], [global]), Second}},
+      chunk_processor_loop(Pid);
+    eof ->
+      logger:info(#{label => "Chunk processor finished."}),
+      Pid ! eof;
+    M ->
+      logger:error(#{label => "Unexpected message", msg => M})
+  end.
+
+%%
+%% The line processor
+%%
+
+line_processor() ->
+  proc_lib:init_ack(self()),
+  line_processor_loop(undefined).
+
+line_processor_loop(ResultPid) ->
+  receive
+    {result_pid, Pid} ->
+      line_processor_loop(Pid);
+    {lines, {Lines, Tail}} ->
+      process_lines(Lines, Tail),
+      line_processor_loop(ResultPid);
+    eof ->
+      Map = maps:from_list(get()),
+      ResultPid ! {result, self(), Map},
+      {heap_size, HeapSize} = process_info(self(), heap_size),
+      logger:info(#{label => "Line processor finished",
+                    heap_size => HeapSize}),
+      ok;
+    M ->
+      logger:error(#{label => "Unexpected message", msg => M})
+  end.
+
+process_lines(Main, Tail) ->
+    case process_lines(Main) of
+        [] ->
+            <<>> = Tail,
+            ok;
+        Rest when Tail =/= <<>> ->
+            process_lines(Rest);
+        [Station] ->
+            process_lines(binary:split(<<Station/binary, Tail/binary>>, [<<";">>]));
+        [Station, Temp] ->
+            process_lines([Station, <<Temp/binary, Tail/binary>>])
+    end.
+process_lines([Station, TempBin|Rest]) when Rest =/= [] ->
+  Temp = parse_float(TempBin),
+  case get(Station) of
+    undefined ->
+      put(Station, { Temp % min
+                   , Temp % max
+                   , 1    % count
+                   , Temp % sum
+                   });
+
+    {OldMin, OldMax, OldCount, OldSum} ->
+      put(Station, { min(OldMin, Temp)
+                   , max(OldMax, Temp)
+                   , OldCount + 1
+                   , OldSum + Temp
+                   })
+
+  end,
+    process_lines(Rest);
+process_lines(Rest) ->
+    Rest.
+
+
+%% Very specialized float-parser for floats with a single fractional
+%% digit, and returns the result as an integer * 10.
+-define(TO_NUM(C), (C - $0)).
+
+parse_float(<<$-, A, B, $., C>>) ->
+  -1 * (?TO_NUM(A) * 100 + ?TO_NUM(B) * 10 + ?TO_NUM(C));
+parse_float(<<$-, B, $., C>>) ->
+  -1 * (?TO_NUM(B) * 10 + ?TO_NUM(C));
+parse_float(<<A, B, $., C>>) ->
+  ?TO_NUM(A) * 100 + ?TO_NUM(B) * 10 + ?TO_NUM(C);
+parse_float(<<B, $., C>>) ->
+  ?TO_NUM(B) * 10 + ?TO_NUM(C).
+
+-ifdef(TEST).
+
+parse_float_test() ->
+  lists:foreach(fun({Bin, Exp}) ->
+                    Float = parse_float(Bin),
+                    ?debugVal({Bin, Float}),
+                    ?assert(abs(Exp - Float) =< 0.0001)
+                end,
+                [ {<<"-0.5">>, -5}
+                , {<<"-10.5">>, -105}
+                , {<<"10.5">>, 105}
+                ]).
+
+-endif.

--- a/src/aggregate2.erl
+++ b/src/aggregate2.erl
@@ -5,25 +5,22 @@
         , chunk_processor/0
         ]).
 
--compile({inline,[{process_temp,1},{process_line,2}]}).
+-compile({inline,[{process_temp,2},{process_line,3}]}).
 
 -include_lib("eunit/include/eunit.hrl").
 
 run([Filename]) ->
-%    logger:update_primary_config(#{ level => none }),
-%    dbg:tracer(),dbg:p(all,c),dbg:tpl(?MODULE,x),
-    aggregate_measurements(atom_to_list(Filename), [%{bufsize, 2 * 1024 * 1024}%, {parallel, 1}
-                                                    {bufsize, 10 * 1024}%, {parallel, 1}
-                                                   ]).
+    logger:update_primary_config(#{ level => none }),
+    aggregate_measurements(atom_to_list(Filename), [{bufsize, 2 * 1024 * 1240}]).
 
 aggregate_measurements(Filename, Opts) ->
   process_flag(trap_exit, true),
   Start = erlang:monotonic_time(),
   BufSize = proplists:get_value(bufsize, Opts),
   logger:info(#{bufsize => BufSize}),
+  {ok, FD} = file:open(Filename, [raw, read, binary]),
   NumProcessors =
     proplists:get_value(parallel, Opts, erlang:system_info(schedulers)),
-  {ok, FD} = file:open(Filename, [raw, read, binary]),
   {ProcessorPids, AllPids} = start_processors(NumProcessors),
   {ok, Bin} = file:pread(FD, 0, BufSize),
   read_chunks(FD, 0, byte_size(Bin), Bin, BufSize, ProcessorPids, NumProcessors * 3),
@@ -57,32 +54,30 @@ read_chunks(FD, N, Offset, PrevChunk, BufSize, TargetPids, 0) ->
             read_chunks(FD, N, Offset, PrevChunk, BufSize, TargetPids, 1)
     end;
 read_chunks(FD, N, Offset, PrevChunk, BufSize, TargetPids, Outstanding) ->
-    TargetPid = lists:nth((N rem length(TargetPids)) + 1, TargetPids),
-    case file:pread(FD, Offset, BufSize) of
-        {ok, Bin} ->
-            Size = byte_size(Bin),
-            %% Read chunks pair-wise and split them so that each processed
-            %% chunk is on an even newline boundary
-            case binary:split(Bin, <<"\n">>) of
-                [First, NextChunk] ->
-                    send_chunk([PrevChunk, First], TargetPid),
-                    %% sleep_if_target_pid_mql_too_long(TargetPid, 20),
-                    read_chunks(FD, N + 1, Offset + Size, NextChunk, BufSize, TargetPids, Outstanding - 1);
-                [Chunk] ->
-                    send_chunk([Chunk], TargetPid),
-                    read_chunks(FD, N + 1, Offset + Size, <<>>, BufSize, TargetPids, Outstanding - 1)
-            end;
-        eof ->
-            %% Reached end of file, process the last chunk
-            send_chunk([PrevChunk], TargetPid),
-            lists:foreach(fun(Pid) -> Pid ! eof end, TargetPids),
-            ok
-    end.
+  TargetPid = lists:nth((N rem length(TargetPids)) + 1, TargetPids),
+  case file:pread(FD, Offset, BufSize) of
+    {ok, Bin} ->
+      Size = byte_size(Bin),
+      %% Read chunks pair-wise and split them so that each processed
+      %% chunk is on an even newline boundary
+      case binary:split(Bin, <<"\n">>) of
+        [First, NextChunk] ->
+          send_chunk([PrevChunk, First], TargetPid),
+          %% sleep_if_target_pid_mql_too_long(TargetPid, 20),
+          read_chunks(FD, N + 1, Offset + Size, NextChunk, BufSize, TargetPids, Outstanding - 1);
+        [Chunk] ->
+          send_chunk([Chunk], TargetPid),
+          read_chunks(FD, N + 1, Offset + Size, <<>>, BufSize, TargetPids, Outstanding - 1)
+      end;
+    eof ->
+      %% Reached end of file, process the last chunk
+      send_chunk([PrevChunk], TargetPid),
+      lists:foreach(fun(Pid) -> Pid ! eof end, TargetPids),
+      ok
+  end.
 
 send_chunk(Chunk, TargetPid) ->
-    Buff = prim_buffer:new(),
-    prim_buffer:write(Buff, Chunk),
-    TargetPid ! {chunk, Buff}.
+  TargetPid ! {chunk, Chunk}.
 
 wait_for_completion([], Map) ->
   logger:info(#{label => "All subprocesses finished"}),
@@ -156,10 +151,21 @@ chunk_processor_loop(Pid) ->
   receive
     {result_pid, NewPid} ->
       chunk_processor_loop(NewPid);
-    {chunk, Buff} ->
-          process_line(Buff),
+    {chunk, [Chunk]} ->
+      process_station(Chunk),
           Pid ! give_me_more,
-          chunk_processor_loop(Pid);
+      chunk_processor_loop(Pid);
+    {chunk, [First, Second]} ->
+          case process_station(First) of
+              <<>> ->
+                  ok;
+              {Rest, Station} ->
+                  process_temp(<<Rest/binary, Second/binary>>, Station);
+              Rest ->
+                  process_station(<<Rest/binary, Second/binary>>)
+          end,
+          Pid ! give_me_more,
+      chunk_processor_loop(Pid);
     eof ->
       Map = maps:from_list(get()),
       Pid ! {result, self(), Map},
@@ -175,38 +181,30 @@ chunk_processor_loop(Pid) ->
 %% The line processor
 %%
 
-process_line(Buff) ->
-    case prim_buffer:find_byte_index(Buff, $;) of
-        {ok, StationIndex} ->
-            Station = prim_buffer:read(Buff, StationIndex),
-            prim_buffer:skip(Buff, 1),
-            case prim_buffer:find_byte_index(Buff, $\n) of
-                {ok, TempIndex} ->
-                    Temp = prim_buffer:read(Buff, TempIndex),
-                    prim_buffer:skip(Buff, 1),
-                    process_line(Station, process_temp(Temp)),
-                    process_line(Buff);
-                not_found ->
-                    Temp = prim_buffer:read(Buff, prim_buffer:size(Buff)),
-                    process_line(Station, process_temp(Temp))
-            end;
-        not_found ->
-            % <<>> = prim_buffer:read(Buff, prim_buffer:size(Buff)),
-            ok
-    end.
+process_station(Station) ->
+    process_station(Station, Station, 0).
+process_station(Bin, <<";", Rest/bitstring>>, Cnt) ->
+    <<Station:Cnt/binary, _/bitstring>> = Bin,
+    process_temp(Rest, Station);
+process_station(Bin, <<_:8, Rest/bitstring>>, Cnt) ->
+    process_station(Bin, Rest, Cnt + 1);
+process_station(Bin, _, _Cnt) ->
+    Bin.
 
 -define(TO_NUM(C), (C - $0)).
 
-process_temp(<<$-, A, B, $., C>>) ->
-    -1 * (?TO_NUM(A) * 100 + ?TO_NUM(B) * 10 + ?TO_NUM(C));
-process_temp(<<$-, B, $., C>>) ->
-    -1 * (?TO_NUM(B) * 10 + ?TO_NUM(C));
-process_temp(<<A, B, $., C>>) ->
-    ?TO_NUM(A) * 100 + ?TO_NUM(B) * 10 + ?TO_NUM(C);
-process_temp(<<B, $., C>>) ->
-    ?TO_NUM(B) * 10 + ?TO_NUM(C).
+process_temp(<<$-, A, B, $., C, Rest/binary>>, Station) ->
+    process_line(Rest, Station, -1 * (?TO_NUM(A) * 100 + ?TO_NUM(B) * 10 + ?TO_NUM(C)));
+process_temp(<<$-, B, $., C, Rest/binary>>, Station) ->
+    process_line(Rest, Station, -1 * (?TO_NUM(B) * 10 + ?TO_NUM(C)));
+process_temp(<<A, B, $., C, Rest/binary>>, Station) ->
+    process_line(Rest, Station, ?TO_NUM(A) * 100 + ?TO_NUM(B) * 10 + ?TO_NUM(C));
+process_temp(<<B, $., C, Rest/binary>>, Station) ->
+    process_line(Rest, Station, ?TO_NUM(B) * 10 + ?TO_NUM(C));
+process_temp(Rest, Station) ->
+    {Rest, Station}.
 
-process_line(Station, Temp) ->
+process_line(Rest, Station, Temp) ->
     case get(Station) of
         undefined ->
             put(Station, { Temp % min
@@ -222,4 +220,9 @@ process_line(Station, Temp) ->
                          , OldSum + Temp
                          })
 
+    end,
+    case Rest of
+        <<>> -> <<>>;
+        <<"\n",NextStation/binary>> ->
+            process_station(NextStation)
     end.

--- a/src/aggregate2.erl
+++ b/src/aggregate2.erl
@@ -5,22 +5,25 @@
         , chunk_processor/0
         ]).
 
--compile({inline,[{process_temp,2},{process_line,3}]}).
+-compile({inline,[{process_temp,1},{process_line,2}]}).
 
 -include_lib("eunit/include/eunit.hrl").
 
 run([Filename]) ->
-    logger:update_primary_config(#{ level => none }),
-    aggregate_measurements(atom_to_list(Filename), [{bufsize, 2 * 1024 * 1240}]).
+%    logger:update_primary_config(#{ level => none }),
+%    dbg:tracer(),dbg:p(all,c),dbg:tpl(?MODULE,x),
+    aggregate_measurements(atom_to_list(Filename), [%{bufsize, 2 * 1024 * 1024}%, {parallel, 1}
+                                                    {bufsize, 10 * 1024}%, {parallel, 1}
+                                                   ]).
 
 aggregate_measurements(Filename, Opts) ->
   process_flag(trap_exit, true),
   Start = erlang:monotonic_time(),
   BufSize = proplists:get_value(bufsize, Opts),
   logger:info(#{bufsize => BufSize}),
-  {ok, FD} = file:open(Filename, [raw, read, binary]),
   NumProcessors =
     proplists:get_value(parallel, Opts, erlang:system_info(schedulers)),
+  {ok, FD} = file:open(Filename, [raw, read, binary]),
   {ProcessorPids, AllPids} = start_processors(NumProcessors),
   {ok, Bin} = file:pread(FD, 0, BufSize),
   read_chunks(FD, 0, byte_size(Bin), Bin, BufSize, ProcessorPids, NumProcessors * 3),
@@ -54,30 +57,32 @@ read_chunks(FD, N, Offset, PrevChunk, BufSize, TargetPids, 0) ->
             read_chunks(FD, N, Offset, PrevChunk, BufSize, TargetPids, 1)
     end;
 read_chunks(FD, N, Offset, PrevChunk, BufSize, TargetPids, Outstanding) ->
-  TargetPid = lists:nth((N rem length(TargetPids)) + 1, TargetPids),
-  case file:pread(FD, Offset, BufSize) of
-    {ok, Bin} ->
-      Size = byte_size(Bin),
-      %% Read chunks pair-wise and split them so that each processed
-      %% chunk is on an even newline boundary
-      case binary:split(Bin, <<"\n">>) of
-        [First, NextChunk] ->
-          send_chunk([PrevChunk, First], TargetPid),
-          %% sleep_if_target_pid_mql_too_long(TargetPid, 20),
-          read_chunks(FD, N + 1, Offset + Size, NextChunk, BufSize, TargetPids, Outstanding - 1);
-        [Chunk] ->
-          send_chunk([Chunk], TargetPid),
-          read_chunks(FD, N + 1, Offset + Size, <<>>, BufSize, TargetPids, Outstanding - 1)
-      end;
-    eof ->
-      %% Reached end of file, process the last chunk
-      send_chunk([PrevChunk], TargetPid),
-      lists:foreach(fun(Pid) -> Pid ! eof end, TargetPids),
-      ok
-  end.
+    TargetPid = lists:nth((N rem length(TargetPids)) + 1, TargetPids),
+    case file:pread(FD, Offset, BufSize) of
+        {ok, Bin} ->
+            Size = byte_size(Bin),
+            %% Read chunks pair-wise and split them so that each processed
+            %% chunk is on an even newline boundary
+            case binary:split(Bin, <<"\n">>) of
+                [First, NextChunk] ->
+                    send_chunk([PrevChunk, First], TargetPid),
+                    %% sleep_if_target_pid_mql_too_long(TargetPid, 20),
+                    read_chunks(FD, N + 1, Offset + Size, NextChunk, BufSize, TargetPids, Outstanding - 1);
+                [Chunk] ->
+                    send_chunk([Chunk], TargetPid),
+                    read_chunks(FD, N + 1, Offset + Size, <<>>, BufSize, TargetPids, Outstanding - 1)
+            end;
+        eof ->
+            %% Reached end of file, process the last chunk
+            send_chunk([PrevChunk], TargetPid),
+            lists:foreach(fun(Pid) -> Pid ! eof end, TargetPids),
+            ok
+    end.
 
 send_chunk(Chunk, TargetPid) ->
-  TargetPid ! {chunk, Chunk}.
+    Buff = prim_buffer:new(),
+    prim_buffer:write(Buff, Chunk),
+    TargetPid ! {chunk, Buff}.
 
 wait_for_completion([], Map) ->
   logger:info(#{label => "All subprocesses finished"}),
@@ -151,21 +156,10 @@ chunk_processor_loop(Pid) ->
   receive
     {result_pid, NewPid} ->
       chunk_processor_loop(NewPid);
-    {chunk, [Chunk]} ->
-      process_station(Chunk),
+    {chunk, Buff} ->
+          process_line(Buff),
           Pid ! give_me_more,
-      chunk_processor_loop(Pid);
-    {chunk, [First, Second]} ->
-          case process_station(First) of
-              <<>> ->
-                  ok;
-              {Rest, Station} ->
-                  process_temp(<<Rest/binary, Second/binary>>, Station);
-              Rest ->
-                  process_station(<<Rest/binary, Second/binary>>)
-          end,
-          Pid ! give_me_more,
-      chunk_processor_loop(Pid);
+          chunk_processor_loop(Pid);
     eof ->
       Map = maps:from_list(get()),
       Pid ! {result, self(), Map},
@@ -181,30 +175,38 @@ chunk_processor_loop(Pid) ->
 %% The line processor
 %%
 
-process_station(Station) ->
-    process_station(Station, Station, 0).
-process_station(Bin, <<";", Rest/bitstring>>, Cnt) ->
-    <<Station:Cnt/binary, _/bitstring>> = Bin,
-    process_temp(Rest, Station);
-process_station(Bin, <<_:8, Rest/bitstring>>, Cnt) ->
-    process_station(Bin, Rest, Cnt + 1);
-process_station(Bin, _, _Cnt) ->
-    Bin.
+process_line(Buff) ->
+    case prim_buffer:find_byte_index(Buff, $;) of
+        {ok, StationIndex} ->
+            Station = prim_buffer:read(Buff, StationIndex),
+            prim_buffer:skip(Buff, 1),
+            case prim_buffer:find_byte_index(Buff, $\n) of
+                {ok, TempIndex} ->
+                    Temp = prim_buffer:read(Buff, TempIndex),
+                    prim_buffer:skip(Buff, 1),
+                    process_line(Station, process_temp(Temp)),
+                    process_line(Buff);
+                not_found ->
+                    Temp = prim_buffer:read(Buff, prim_buffer:size(Buff)),
+                    process_line(Station, process_temp(Temp))
+            end;
+        not_found ->
+            % <<>> = prim_buffer:read(Buff, prim_buffer:size(Buff)),
+            ok
+    end.
 
 -define(TO_NUM(C), (C - $0)).
 
-process_temp(<<$-, A, B, $., C, Rest/binary>>, Station) ->
-    process_line(Rest, Station, -1 * (?TO_NUM(A) * 100 + ?TO_NUM(B) * 10 + ?TO_NUM(C)));
-process_temp(<<$-, B, $., C, Rest/binary>>, Station) ->
-    process_line(Rest, Station, -1 * (?TO_NUM(B) * 10 + ?TO_NUM(C)));
-process_temp(<<A, B, $., C, Rest/binary>>, Station) ->
-    process_line(Rest, Station, ?TO_NUM(A) * 100 + ?TO_NUM(B) * 10 + ?TO_NUM(C));
-process_temp(<<B, $., C, Rest/binary>>, Station) ->
-    process_line(Rest, Station, ?TO_NUM(B) * 10 + ?TO_NUM(C));
-process_temp(Rest, Station) ->
-    {Rest, Station}.
+process_temp(<<$-, A, B, $., C>>) ->
+    -1 * (?TO_NUM(A) * 100 + ?TO_NUM(B) * 10 + ?TO_NUM(C));
+process_temp(<<$-, B, $., C>>) ->
+    -1 * (?TO_NUM(B) * 10 + ?TO_NUM(C));
+process_temp(<<A, B, $., C>>) ->
+    ?TO_NUM(A) * 100 + ?TO_NUM(B) * 10 + ?TO_NUM(C);
+process_temp(<<B, $., C>>) ->
+    ?TO_NUM(B) * 10 + ?TO_NUM(C).
 
-process_line(Rest, Station, Temp) ->
+process_line(Station, Temp) ->
     case get(Station) of
         undefined ->
             put(Station, { Temp % min
@@ -220,9 +222,4 @@ process_line(Rest, Station, Temp) ->
                          , OldSum + Temp
                          })
 
-    end,
-    case Rest of
-        <<>> -> <<>>;
-        <<"\n",NextStation/binary>> ->
-            process_station(NextStation)
     end.

--- a/src/aggregate2.erl
+++ b/src/aggregate2.erl
@@ -23,7 +23,7 @@ aggregate_measurements(Filename, Opts) ->
     proplists:get_value(parallel, Opts, erlang:system_info(schedulers)),
   {ProcessorPids, AllPids} = start_processors(NumProcessors),
   {ok, Bin} = file:pread(FD, 0, BufSize),
-  read_chunks(FD, 0, byte_size(Bin), Bin, BufSize, ProcessorPids),
+  read_chunks(FD, 0, byte_size(Bin), Bin, BufSize, ProcessorPids, NumProcessors * 3),
   Now = erlang:monotonic_time(),
   logger:info(#{label => "All chunks read, waiting for processors to finish",
                 elapsed_secs => (Now - Start) / 1000_000_000.0}),
@@ -48,7 +48,12 @@ start_processors(NumProcs) ->
          [ProcessorPid|AllPids]}
     end, {[], []}, lists:seq(1, NumProcs)).
 
-read_chunks(FD, N, Offset, PrevChunk, BufSize, TargetPids) ->
+read_chunks(FD, N, Offset, PrevChunk, BufSize, TargetPids, 0) ->
+    receive
+        give_me_more ->
+            read_chunks(FD, N, Offset, PrevChunk, BufSize, TargetPids, 1)
+    end;
+read_chunks(FD, N, Offset, PrevChunk, BufSize, TargetPids, Outstanding) ->
   TargetPid = lists:nth((N rem length(TargetPids)) + 1, TargetPids),
   case file:pread(FD, Offset, BufSize) of
     {ok, Bin} ->
@@ -59,10 +64,10 @@ read_chunks(FD, N, Offset, PrevChunk, BufSize, TargetPids) ->
         [First, NextChunk] ->
           send_chunk([PrevChunk, First], TargetPid),
           %% sleep_if_target_pid_mql_too_long(TargetPid, 20),
-          read_chunks(FD, N + 1, Offset + Size, NextChunk, BufSize, TargetPids);
+          read_chunks(FD, N + 1, Offset + Size, NextChunk, BufSize, TargetPids, Outstanding - 1);
         [Chunk] ->
           send_chunk([Chunk], TargetPid),
-          read_chunks(FD, N + 1, Offset + Size, <<>>, BufSize, TargetPids)
+          read_chunks(FD, N + 1, Offset + Size, <<>>, BufSize, TargetPids, Outstanding - 1)
       end;
     eof ->
       %% Reached end of file, process the last chunk
@@ -86,6 +91,8 @@ wait_for_completion(Pids, Map) ->
                     sender => SenderPid,
                     result_size => maps:size(NewMap)}),
       wait_for_completion(Pids, merge_location_data(Map, NewMap));
+      give_me_more ->
+          wait_for_completion(Pids, Map);
     M ->
       logger:error(#{label => "Unexpected message", msg => M})
   end.
@@ -146,6 +153,7 @@ chunk_processor_loop(Pid) ->
       chunk_processor_loop(NewPid);
     {chunk, [Chunk]} ->
       process_station(Chunk),
+          Pid ! give_me_more,
       chunk_processor_loop(Pid);
     {chunk, [First, Second]} ->
           case process_station(First) of
@@ -156,6 +164,7 @@ chunk_processor_loop(Pid) ->
               Rest ->
                   process_station(<<Rest/binary, Second/binary>>)
           end,
+          Pid ! give_me_more,
       chunk_processor_loop(Pid);
     eof ->
       Map = maps:from_list(get()),

--- a/src/erlang_1brc.erl
+++ b/src/erlang_1brc.erl
@@ -9,6 +9,7 @@ options() ->
   , {log_level, $l, "log_level", {atom, info},                "Log level."}
   , {no_output, undefined, "no_output", undefined,            "Do not print output to stdout."}
   , {parallel,  $p, "parallel", integer,                      "Number of parallel processing pipelines."}
+  , {backend, $b, "backend", {atom, aggregate}, "The backend to use"}
   ].
 
 main(Args) ->
@@ -44,5 +45,6 @@ main(Args) ->
 
 do_main(Opts) ->
   Filename = proplists:get_value(file, Opts),
-  {Time, _} = timer:tc(fun() -> aggregate:aggregate_measurements(Filename, Opts) end),
+    Backend = proplists:get_value(backend, Opts),
+  {Time, _} = timer:tc(fun() -> Backend:aggregate_measurements(Filename, Opts) end),
   Time.


### PR DESCRIPTION
Always fun with a good benchmark competition :D

I updated your attempt to send a list of binaries (iovec) instead of a binary to the chunk processor to eliminate a copy of the read binary, and then I used binary syntax to parse instead of binary:split. On my machine the execution time for 1B measurements went from ~90 seconds to ~60 seconds.