### PR TITLE
Reusing match context and precompute station keys

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,8 @@ if [ -z "$INPUT" ]; then
 fi
 
 set -e
-erlc -W src/erlang_1brc.erl
+# erlc +bin_opt_info -W src/erlang_1brc.erl
+erlc -W src/erlang_1brc.erl || exit 1
 /bin/time -f "Elapsed time: %e seconds (%E)" \
     erl \
     -noinput \


### PR DESCRIPTION
Two optimizations here:

1. Rewrite process_station/{1,2} to make sure that they can reuse their binary match contexts. See [this blog
post](https://engineering.klarna.com/using-continuation-passing-style-to-optimize-recursive-decoding-of-binaries-in-erlang-6e7241a462b7) for more info about this.

2. Instead of using the full station name as a key when storing the temperature data, compute a "compressed key". This is such that it can be computed in a streaming fashion as the binary is traversed such that the optimization in (1) still applies.